### PR TITLE
Re enable nowait enhanced

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.12.0'
+__version__ = '1.12.1'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.12.1'
+__version__ = '1.12.2'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/conductor.py
+++ b/faust/transport/conductor.py
@@ -131,12 +131,12 @@ class ConductorCompiler:  # pragma: no cover
                             event_keyid = keyid
 
                             queue = chan.queue
-                            # queue.put_nowait_enhanced(
-                            #     event,
-                            #     on_pressure_high=on_pressure_high,
-                            #     on_pressure_drop=on_pressure_drop,
-                            # )
-                            queue.put_nowait(event)
+                            queue.put_nowait_enhanced(
+                                event,
+                                on_pressure_high=on_pressure_high,
+                                on_pressure_drop=on_pressure_drop,
+                            )
+                            # queue.put_nowait(event)
                         else:
                             # subsequent channels may have a different
                             # key/value type pair, meaning they all can
@@ -150,12 +150,12 @@ class ConductorCompiler:  # pragma: no cover
                                 dest_event = await chan.decode(
                                     message, propagate=True)
                             queue = chan.queue
-                            # queue.put_nowait_enhanced(
-                            #     dest_event,
-                            #     on_pressure_high=on_pressure_high,
-                            #     on_pressure_drop=on_pressure_drop,
-                            # )
-                            queue.put_nowait(dest_event)
+                            queue.put_nowait_enhanced(
+                                dest_event,
+                                on_pressure_high=on_pressure_high,
+                                on_pressure_drop=on_pressure_drop,
+                            )
+                            # queue.put_nowait(dest_event)
                         delivered.add(chan)
 
                 except KeyDecodeError as exc:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,7 +3,7 @@ aiohttp_cors>=0.7,<2.0
 dt-aiokafka==1.1.8
 click>=6.7,<8.0
 colorclass>=2.2,<3.0
-mode>=4.3.2,<4.4
+dt-mode>=4.4.0
 opentracing>=1.3.0,<2.0.0
 terminaltables>=3.1,<4.0
 venusian>=1.1,<2.0

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ LDFLAGS = []
 LIBRARIES = []
 E_UNSUPPORTED_PYTHON = NAME + ' 1.0 requires Python %%s or later!'
 
-if sys.version_info < (3, 6):
-    raise Exception(E_UNSUPPORTED_PYTHON % ('3.6',))  # NOQA
+if sys.version_info < (3, 8):
+    raise Exception(E_UNSUPPORTED_PYTHON % ('3.8',))  # NOQA
 
 from pathlib import Path  # noqa
 
@@ -207,7 +207,7 @@ def do_setup(**kwargs):
         # PEP-561: https://www.python.org/dev/peps/pep-0561/
         package_data={'faust': ['py.typed']},
         include_package_data=True,
-        python_requires='>=3.6.0',
+        python_requires='>=3.8.0',
         zip_safe=False,
         install_requires=reqs('default.txt'),
         tests_require=reqs('test.txt'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = 3.8,3.7,3.6,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
+# envlist = 3.8,3.7,3.6,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
+envlist = 3.8,flake8,apicheck,configcheck,typecheck,docstyle,bandit,spell
 
 [testenv]
 deps=


### PR DESCRIPTION
Requires a tagged version of mode, so this now imports a private version of mode that was released from it's present master. Also makes this require python 3.8, since mode sometimes logs in a python 3.8-specific way.
