### PR TITLE
shift to using IntervalTree for gaps to handle large recovery situations

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.12.6'
+__version__ = '1.12.7'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -992,8 +992,12 @@ class Consumer(Service, ConsumerT):
             max_offset = max(acked)
             gap_for_tp: IntervalTree = self._gap[tp]
             if gap_for_tp:
-                # find all the ranges up to the max of acked
+                # find all the ranges up to the max of acked, add them in to acked,
+                # and chop them off the gap.
                 candidates = gap_for_tp.overlap(0, max_offset)
+                # note: merge_overlaps will sort the intervaltree and will ensure that
+                # the intervals left over don't overlap each other. So can sort by their
+                # start without worrying about ends overlapping.
                 sorted_candidates = sorted(candidates, key=lambda x: x.begin)
                 if sorted_candidates:
                     stuff_to_add = list()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -10,3 +10,4 @@ venusian>=1.1,<2.0
 yarl>=1.0,<2.0
 croniter>=0.3.16
 mypy_extensions
+intervaltree

--- a/requirements/dist.txt
+++ b/requirements/dist.txt
@@ -12,3 +12,4 @@ tox>=2.3.1
 twine
 vulture
 wheel>=0.29.0
+intervaltree

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -983,6 +983,11 @@ class test_Consumer:
                        Interval(5, 6),
                        Interval(9, 10)]),
          10),
+        (TP1, [1, 2, 3, 4, 5, 6, 7, 8, 10],
+         IntervalTree([Interval(9, 10),
+                       Interval(11, 15)]),
+         10
+         )
     ])
     def test_new_offset_with_gaps(self, tp, acked, gaps,
                                   expected_offset, *, consumer):


### PR DESCRIPTION
The `_gap` variable on a consumer can grow quite large if the consumer is re-reading a large partition or one with a lot of offsets (for example, recovering from a compacted topic with a lot of changes). Rather than having `_gap` be a list of every possible missing offset, use an `intervaltree` to store ranges of missing offsets. This assumes that the offsets stored in `_gap` can be collapsed down to continuous intervals. 

In theory, this should address https://github.com/faust-streaming/faust/issues/86 in the `faust-streaming` fork, they're welcome to grab this & apply it to their stuff also. 