### PR TITLE
add await in _add_gap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -452,7 +452,7 @@ Slack
 -----
 
 For discussions about the usage, development, and future of Faust,
-please join the `fauststream`_ Slack.
+please join the `fauststream` Slack.
 
 * https://fauststream.slack.com
 * Sign-up: https://join.slack.com/t/fauststream/shared_invite/enQtNDEzMTIyMTUyNzU2LTIyMjNjY2M2YzA2OWFhMDlmMzVkODk3YTBlYThlYmZiNTUwZDJlYWZiZTdkN2Q4ZGU4NWM4YWMyNTM5MGQ5OTg

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.12.7'
+__version__ = '1.12.8'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -1027,7 +1027,7 @@ class Consumer(Service, ConsumerT):
         """Call when processing a message failed."""
         await self.commit()
 
-    def _add_gap(self, tp: TP, offset_from: int, offset_to: int) -> None:
+    async def _add_gap(self, tp: TP, offset_from: int, offset_to: int) -> None:
         committed = self._committed_offset[tp]
         gap_for_tp = self._gap[tp]
         if committed is not None:
@@ -1035,6 +1035,9 @@ class Consumer(Service, ConsumerT):
         # intervaltree intervals exclude the end
         if offset_from <= offset_to:
             gap_for_tp.addi(offset_from, offset_to + 1)
+            # sleep 0 to allow other coroutines to get some loop time
+            # for example, to answer health checks while building the gap
+            await asyncio.sleep(0)
             gap_for_tp.merge_overlaps()
         # original faust code
         # for offset in range(offset_from, offset_to):
@@ -1087,7 +1090,7 @@ class Consumer(Service, ConsumerT):
                             if gap > 1 and r_offset:
                                 acks_enabled = acks_enabled_for(message.topic)
                                 if acks_enabled:
-                                    self._add_gap(tp, r_offset + 1, offset)
+                                    await self._add_gap(tp, r_offset + 1, offset)
                             if commit_every is not None:
                                 if self._n_acked >= commit_every:
                                     self._n_acked = 0

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -1001,17 +1001,19 @@ class test_Consumer:
         await consumer.on_task_error(KeyError())
         consumer.commit.assert_called_once_with()
 
-    def test__add_gap(self, *, consumer):
+    @pytest.mark.asyncio
+    async def test__add_gap(self, *, consumer):
         tp = TP1
         consumer._committed_offset[tp] = 299
-        consumer._add_gap(TP1, 300, 343)
+        await consumer._add_gap(TP1, 300, 343)
 
         assert consumer._gap[tp] == IntervalTree([Interval(300, 344)])
 
-    def test__add_gap__previous_to_committed(self, *, consumer):
+    @pytest.mark.asyncio
+    async def test__add_gap__previous_to_committed(self, *, consumer):
         tp = TP1
         consumer._committed_offset[tp] = 400
-        consumer._add_gap(TP1, 300, 343)
+        await consumer._add_gap(TP1, 300, 343)
 
         assert consumer._gap[tp] == IntervalTree()
 


### PR DESCRIPTION
make _add_gap async with an await to allow other coroutines to get runtime (to allow them to answer health checks, for example)

Anyone fixing https://github.com/faust-streaming/faust/issues/86 probably wants this also.